### PR TITLE
Fix to remove Spotify's notice from .csv file

### DIFF
--- a/charts.py
+++ b/charts.py
@@ -50,7 +50,7 @@ def header_handler(df):
         column_names = df[find_row].values.tolist()
         drop_row = df.index[find_row].tolist()
         df = df.drop(drop_row)
-        df.columns = [item for sublist in column_names for item in sublist] # Unnest
+        df.columns = column_names
         df = df.dropna() # Drop row with Spotify's notice
         df = df.reset_index(drop=True)
     return df 

--- a/charts.py
+++ b/charts.py
@@ -25,6 +25,7 @@ def get_chart(date, region='en', freq='daily', chart='top200'):
     data = io.StringIO(requests.get(url).text)
     try:
         df = pd.read_csv(data)
+        df = header_handler(df) # Remove Spotify's notice from DataFrame
     except pd.errors.ParserError:
         df = None
         print(data)
@@ -41,6 +42,18 @@ def get_charts(start, end, region='en', freq='daily', chart='top200', sleep=1):
             dfs.append(df)
             time.sleep(sleep)
     return pd.concat(dfs)
+
+
+def header_handler(df):
+    find_row = df[0] == 'Position'
+    if True in find_row:
+        column_names = df[find_row].values.tolist()
+        drop_row = df.index[find_row].tolist()
+        df = df.drop(drop_row)
+        df.columns = column_names
+        df = df.dropna() # Drop row with Spotify's notice
+        df = df.reset_index(drop=True)
+    return df 
 
 
 if __name__ == '__main__':

--- a/charts.py
+++ b/charts.py
@@ -45,7 +45,7 @@ def get_charts(start, end, region='en', freq='daily', chart='top200', sleep=1):
 
 
 def header_handler(df):
-    find_row = df[0] == 'Position'
+    find_row = df[df.columns[0]] == 'Position'
     if True in find_row:
         column_names = df[find_row].values.tolist()
         drop_row = df.index[find_row].tolist()

--- a/charts.py
+++ b/charts.py
@@ -50,7 +50,7 @@ def header_handler(df):
         column_names = df[find_row].values.tolist()
         drop_row = df.index[find_row].tolist()
         df = df.drop(drop_row)
-        df.columns = column_names
+        df.columns = [item for sublist in column_names for item in sublist] # Unnest
         df = df.dropna() # Drop row with Spotify's notice
         df = df.reset_index(drop=True)
     return df 


### PR DESCRIPTION
Spotify added an extra row in the downloaded .csv file that breaks the current code and contains the following statement:

> Note that these figures are generated using a formula that protects against any artificial inflation of chart positions.

This PR introduces the header_handler function to sanitize the resulting DataFrame.