### PR TITLE
Fix Spotify's Notice at the beginning of the Chart

### DIFF
--- a/charts.py
+++ b/charts.py
@@ -24,8 +24,7 @@ def get_chart(date, region='en', freq='daily', chart='top200'):
     url = f'https://spotifycharts.com/{chart}/{region}/{freq}/{date}/download'
     data = io.StringIO(requests.get(url).text)
     try:
-        df = pd.read_csv(data)
-        df = header_handler(df) # Remove Spotify's notice from DataFrame
+        df = pd.read_csv(data, skiprows=1) # Fix Spotify's Note
     except pd.errors.ParserError:
         df = None
         print(data)
@@ -42,18 +41,6 @@ def get_charts(start, end, region='en', freq='daily', chart='top200', sleep=1):
             dfs.append(df)
             time.sleep(sleep)
     return pd.concat(dfs)
-
-
-def header_handler(df):
-    find_row = df[df.columns[0]] == 'Position'
-    if True in find_row:
-        column_names = df[find_row].values.tolist()
-        drop_row = df.index[find_row].tolist()
-        df = df.drop(drop_row)
-        df.columns = column_names
-        df = df.dropna() # Drop row with Spotify's notice
-        df = df.reset_index(drop=True)
-    return df 
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The previous `header_handler` method returned a `Dataframe` with Multindex columns. For example, `charts['Artist']` was a `DataFrame`, instead of `Series`. That didn’t allow to use methods such as `describe`, `unique` and `apply` functions in the normal way. This bug fix solves the header keeping the `DataFrame`'s usual properties.